### PR TITLE
Add "linespread" variable to the yaml header

### DIFF
--- a/Abschlussarbeit.Rmd
+++ b/Abschlussarbeit.Rmd
@@ -14,7 +14,6 @@ deadline: "Abgabedatum"
 header-includes:
   - \usepackage[ngerman]{babel}
   - \usepackage{setspace}
-  - \onehalfspacing
 output:
   pdf_document:
     keep_tex: yes

--- a/template.tex
+++ b/template.tex
@@ -180,6 +180,12 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 
+$if(linespread)$
+\linespread{$linespread$}
+$else$
+\onehalfspacing
+$endif$
+
 \begin{document}
 
 %\maketitle


### PR DESCRIPTION
linespread can be set to any numerical value. If not declared it will 
default to Latexs \onehalfspacing option.